### PR TITLE
Ctda 975

### DIFF
--- a/source/documentation/developing-now.html.md
+++ b/source/documentation/developing-now.html.md
@@ -20,9 +20,5 @@ We are carrying out research with developers, testers and business managers. If 
 ## Improving our documentation
 
 As we get your feedback we try and respond to it as fast as we can to improve our documentation and add clarity. We are also continuing to improve and update our documentation.
-For example, items we are currently working on include:
 
-- XML mapping guides  
-- Plain language error descriptions within response messages  
-- Trader test pack content  
 

--- a/source/documentation/index.md
+++ b/source/documentation/index.md
@@ -43,6 +43,7 @@ If you have any questions, or you wish to get in touch, please talk to your usua
 
   * [Service Guide](https://developer.service.hmrc.gov.uk/guides/common-transit-convention-traders-service-guide/)
   * [CTC Traders API specifications](https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/common-transit-convention-traders/1.0)
+  * [CTC Traders Test Support APi specifications](https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/common-transit-convention-traders-test-support/1.0)
 
 ### Changelog
 <!--- Section owner: MTD Programme --->


### PR DESCRIPTION
Change to 'what we are developing now' page and 'related docs' on the index (Added TS API link)