### PR TITLE
CTDA-1130/Cookie-consent-banner

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -2,6 +2,8 @@
 weight: 1
 ---
 
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TSFTCWZ" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+
 <%= partial 'documentation/partials/google_tag_manager_js' %>
 
 <%= partial 'documentation/index' %>


### PR DESCRIPTION
# Cookie consent banner

Re-adding the no-script GA tracking.

[Ticket](https://jira.tools.tax.service.gov.uk/browse/CTDA-1130)