### PR TITLE
CTDA-1146/remove test support refs

### DIFF
--- a/source/documentation/released.html.md.erb
+++ b/source/documentation/released.html.md.erb
@@ -15,7 +15,7 @@ You can now test with the Trader Test service within the sandbox environment.
 
 Trader Test will automatically simulate and give you responses just like in a real life scenario. You can also request NCTS support staff to generate the manual responses as if Border Force staff are processing your goods. 
 
-For more information read [this guide](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/940784/NCTS_Trader_Test_Access_Channels_and_Support_v1.1.pdf) 
+For more information read [this guide](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/940784/NCTS_Trader_Test_Access_Channels_and_Support_v1.1.pdf).
 
 ## CTC Traders API
 


### PR DESCRIPTION
# Remove test support refs

This change is a small one, this is already live, but there is a missing full stop. - non urgent

[Ticket](https://jira.tools.tax.service.gov.uk/browse/CTDA-1146)