### PR TITLE
CTCP-267-moving-validation-departure-to-done

### DIFF
--- a/source/documentation/index.md
+++ b/source/documentation/index.md
@@ -18,17 +18,15 @@ For technical information, see the [CTC Traders API specifications](/api-documen
 ### What have we just released?
 The following is now available to 3rd party developers:
 
-- The [Submit Declaration Data endpoint](/api-documentation/docs/api/service/common-transit-convention-traders/2.0#Send%20a%20Declaration%20Data%20message) is limited to users with CTC EORI enrolment. 
+- Validation of departure declaration data payloads.
 
 ### What are we working on now?
-Validation of departure declaration data payloads.
-
-### What is coming next?
 Enabling the saving of departure declaration information. This allows developers to retrieve departure declaration metadata.
 
 ### What have we already released?
 The following is available to 3rd party developers:
 
+- The [Submit Declaration Data endpoint](/api-documentation/docs/api/service/common-transit-convention-traders/2.0#Send%20a%20Declaration%20Data%20message) is limited to users with CTC EORI enrolment. 
 - The [service guide](/guides/ctc-traders-phase5-service-guide/)
 - A beta version of the departure declaration API endpoint (IE015/CC015C), which allows developers to start a Phase 5 movement using a departure declaration.
 - An example application code, available on [github](https://github.com/hmrc/ctc-traders-example-java-client). This example demonstrates how to generate authentication access tokens and submit a simple declaration.

--- a/source/documentation/index.md
+++ b/source/documentation/index.md
@@ -27,7 +27,7 @@ Enabling the saving of departure declaration information. This allows developers
 The following is available to 3rd party developers:
 
 - The [Submit Declaration Data endpoint](/api-documentation/docs/api/service/common-transit-convention-traders/2.0#Send%20a%20Declaration%20Data%20message) is limited to users with CTC EORI enrolment. 
-- The [service guide](/guides/ctc-traders-phase5-service-guide/)
+- The [service guide](/guides/ctc-traders-phase5-service-guide/).
 - A beta version of the departure declaration API endpoint (IE015/CC015C), which allows developers to start a Phase 5 movement using a departure declaration.
 - An example application code, available on [github](https://github.com/hmrc/ctc-traders-example-java-client). This example demonstrates how to generate authentication access tokens and submit a simple declaration.
 - The new endpoint documentation has been released. To view it:


### PR DESCRIPTION
- Moving "Validation of departure declaration data payloads." to What have we just released.
- Moving "Enabling the saving of departure declaration information. This allows developers to retrieve departure declaration metadata." to What are we working on now.
- Moving "The [Submit Declaration Data endpoint](http://192.168.1.119:4567/api-documentation/docs/api/service/common-transit-convention-traders/2.0#Send%20a%20Declaration%20Data%20message) is limited to users with CTC EORI enrolment." to What have we already released?